### PR TITLE
fix(system): 仅在后端 DEV 模式返回 BACKEND_DEV

### DIFF
--- a/app/api/endpoints/system.py
+++ b/app/api/endpoints/system.py
@@ -164,6 +164,9 @@ def get_global_setting(token: str):
             "BACKEND_VERSION": APP_VERSION,
         }
     )
+    # 仅在后端开发模式下返回该标记，避免生产环境暴露无意义运行态信息
+    if settings.DEV:
+        info.update({"BACKEND_DEV": True})
     return schemas.Response(success=True, data=info)
 
 


### PR DESCRIPTION
变更说明\n- 调整 /api/v1/system/global 的返回字段\n- 仅当后端 DEV=true 时追加返回 BACKEND_DEV: true\n- 生产环境不返回该字段，减少运行态信息暴露\n\n影响路径\n- app/api/endpoints/system.py\n\n复现与验证\n1. 后端 DEV=true 启动，调用 /api/v1/system/global?token=moviepilot，确认返回包含 BACKEND_DEV=true\n2. 后端 DEV=false 启动，调用同接口，确认不包含 BACKEND_DEV 字段\n\n本 PR 为 codex 协作提交